### PR TITLE
installation/executor.py: remove redundant Executor.submit() call

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -168,7 +168,7 @@ class Executor:
                 wait(tasks)
 
                 for operation in serial_operations:
-                    wait([self._executor.submit(self._execute_operation, operation)])
+                    self._execute_operation(operation)
 
             except KeyboardInterrupt:
                 self._shutdown = True


### PR DESCRIPTION
When the ThreadPoolExecutor is idle, this code:
```python
from concurrent.futures import wait, ThreadpoolExecutor
executor: ThreadpoolExecutor
wait([executor.submit(fn, arg)])
```
is equivalent to
```python
fn(arg)
```

Remove one such redundant call in installation/executor.py
